### PR TITLE
External scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ hubot-cron adds a cronjob system to hubot to schedule messages on a specific dat
 
 ## Installation
 
-Add `hubot-cron` to your package.json, run `npm install` and put a symlink from your `scripts` directory.
-
-## Usage
+Add `hubot-cron` to your package.json, run `npm install` and add hubot-cron to `external-scripts.json`.
 
 Add hubot-cron to your `package.json` dependencies.
 
@@ -16,11 +14,11 @@ Add hubot-cron to your `package.json` dependencies.
 }
 ```
 
-Install it and put a symlink from your scripts directory.
+Add `hubot-cron` to `external-scripts.json`.
 
 ```
-> npm install
-> ln -s ../node_modules/hubot-cron/src/scripts/cron.coffee scripts/
+> cat external-scripts.json
+> ["hubot-cron"]
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "Cron job messaging for hubot",
   "homepage": "https://github.com/miyagawa/hubot-cron",
+  "main": "./src/index.coffee",
   "repository": {
     "type": "git",
     "url": "git://github.com/miyagawa/hubot-cron.git"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,0 +1,10 @@
+Fs   = require 'fs'
+Path = require 'path'
+
+module.exports = (robot) ->
+  path = Path.resolve __dirname, 'scripts'
+  Fs.exists path, (exists) ->
+    if exists
+      for file in Fs.readdirSync(path)
+        robot.loadFile path, file
+        robot.parseHelp Path.join(path, file)


### PR DESCRIPTION
Added support of external-scripts.json which allows to use an npm package as hubot script.

See: https://github.com/github/hubot/blob/master/docs/scripting.md#creating-a-script-package
