### PR TITLE
Clone `user` because adapters may touch it later

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -55,7 +55,10 @@ class Job
     @id = id
     @pattern = pattern
     @envelope = {}
-    @envelope.user = user
+    # cloning user because adapter may touch it later
+    clonedUser = {}
+    clonedUser[k] = v for k,v of user
+    @envelope.user = clonedUser
     @message = message
 
   start: (robot) ->


### PR DESCRIPTION
This fixes a bug that cron job sometime sends message to unexpected room.

Adapters may change user.room and reply_to later, with the last room where an
user speaked.

e.g.
https://github.com/hipchat/hubot-hipchat/blob/3cd23598c6a33c827dbe286fe673287e2d642fb8/src/hipchat.coffee#L131-L133
