### PR TITLE
Show reply_to instead of room if available

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -39,7 +39,8 @@ module.exports = (robot) ->
 
   robot.respond /(?:list|ls) jobs?/i, (msg) ->
     for own id, job of robot.brain.data.cronjob
-      msg.send "#{id}: #{job[0]} @#{job[1].room} \"#{job[2]}\""
+      room = job[1].reply_to || job[1].room
+      msg.send "#{id}: #{job[0]} @#{room} \"#{job[2]}\""
 
   robot.respond /(?:rm|remove|del|delete) job (\d+)/i, (msg) ->
     id = msg.match[1]


### PR DESCRIPTION
Hipchat adapter sets `msg.user.reply_to` for jid.

https://github.com/hipchat/hubot-hipchat/blob/master/src/hipchat.coffee#L20-L28
