### PR TITLE
Fix show jobs list when room name undefined.

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -39,7 +39,7 @@ module.exports = (robot) ->
 
   robot.respond /(?:list|ls) jobs?/i, (msg) ->
     for own id, job of robot.brain.data.cronjob
-      room = job[1].reply_to || job[1].room
+      room = job[1].reply_to || job[1].room || job[1].user.reply_to || job[1].user.room
       msg.send "#{id}: #{job[0]} @#{room} \"#{job[2]}\""
 
   robot.respond /(?:rm|remove|del|delete) job (\d+)/i, (msg) ->


### PR DESCRIPTION
Hello. 

In latest hubot-cron, room name is undefined when show `list jobs`.
cause, new define job is `reply_to` and `room` attributes has `jobs[1].user`.
I've made the modifications corresponding to both of the new definition and the old definition Job.

before

```
795789: 30 18 * * 1-5 @room_name "Hello." // Before hubot-cron update defined job.
862341: 58 9 * * * @undefined "test" // After hubot-cron update defined job.
```

after

```
795656: 30 18 * * 1-5 @room_name "Hello."
867501: 58 9 * * * @room_name "test"
```

Please confirm.
Thank you.
