### PR TITLE
Revert serialization of jobs to use User (after cloning) 

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -52,6 +52,7 @@ module.exports = (robot) ->
     if JOBS[id]
       JOBS[id].stop()
       delete robot.brain.data.cronjob[id]
+      delete JOBS[id]
       msg.send "Job #{id} deleted"
     else
       msg.send "Job #{id} does not exist"


### PR DESCRIPTION
and make sure jobs saved during v2.0.0-2 to be compatible. see #8 

cc @TakatoshiMaeda @sorah @bergren2
