### PR TITLE
Remove robot.parseHelp from index.coffee

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -7,4 +7,3 @@ module.exports = (robot) ->
     if exists
       for file in Fs.readdirSync(path)
         robot.loadFile path, file
-        robot.parseHelp Path.join(path, file)


### PR DESCRIPTION
`Robot#parseHelp` is called in `Robot#loadFile`.

https://github.com/github/hubot/blob/master/src/robot.coffee#L217
