### PR TITLE
Specify the room in an envelope

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -100,6 +100,6 @@ class Job
     [@pattern, @user, @message]
 
   sendMessage: (robot) ->
-    envelope = user: @user
+    envelope = user: @user, room: @user.room
     robot.send envelope, @message
 


### PR DESCRIPTION
hubot-cron doesn't work with [slack-adapter](https://github.com/tinyspeck/hubot-slack). Heroku logs are as follows.

> 2014-07-27T08:18:00.755700+00:00 app[web.1]: Sending message
> 2014-07-27T08:18:00.848650+00:00 app[web.1]: Slack services error: 500
> 2014-07-27T08:18:00.848662+00:00 app[web.1]: No channel specified

In slack-adapter, the channel is detected from `envelope.reply_to` or `envelope.room` .
https://github.com/tinyspeck/hubot-slack/blob/master/src/slack.coffee#L25

hipchat-adapter also uses `envelope.room` (in the low priority).
https://github.com/hipchat/hubot-hipchat/blob/master/src/hipchat.coffee#L18

So I think it's reasonable that an envelope hash includes the room.
