### PR TITLE
fix list method + add 'list all'

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -64,9 +64,15 @@ module.exports = (robot) ->
 
   robot.respond /(?:list|ls) jobs?/i, (msg) ->
     for id, job of JOBS
-      room = job.user.reply_to || job.user.room
+      room = job.user.room || job.user.reply_to
       if room == msg.message.user.reply_to or room == msg.message.user.room
         msg.send "#{id}: #{job.pattern} @#{room} \"#{job.message}\""
+
+  robot.respond /(?:list|ls) all jobs?/i, (msg) ->
+    for id, job of JOBS
+      room = job.user.room || job.user.reply_to
+      msg.send "#{id}: #{job.pattern} @#{room} \"#{job.message}\""
+
 
   robot.respond /(?:rm|remove|del|delete) job (\d+)/i, (msg) ->
     if (id = msg.match[1]) and unregisterJob(robot, id)


### PR DESCRIPTION
The user.reply_to id seems to be different everytime hubot is restarted, therefore not a safe option (everytime I restarted hubot, listing jobs wouldn't return any result).
I use the job.user.room by default instead.

Also added a method "list all" to list all jobs recorded in the job brain, regardless of the channel"
