### PR TITLE
Fix cronjob loading from brain in boottime

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -52,6 +52,7 @@ module.exports = (robot) ->
   robot.brain.on 'loaded', =>
     for own id, job of robot.brain.data.cronjob
       registerNewJobFromBrain robot, id, job...
+  robot.brain.emit 'loaded' if Object.keys(robot.brain.data.cronjob).length
 
   robot.respond /(?:new|add) job "(.*?)" (.*)$/i, (msg) ->
     handleNewJob robot, msg, msg.match[1], msg.match[2]


### PR DESCRIPTION
hubot-cronjob script will be loaded after the `loaded` event was emitted to `robot.brain`.
So cronjobs that added to `robot.brain` won't be loaded in boottime.
