### PR TITLE
Handles UTF8 quotes

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -82,10 +82,10 @@ module.exports = (robot) ->
   robot.brain.on 'loaded', =>
     syncJobs robot
 
-  robot.respond /(?:new|add) job "(.*?)" (.*)$/i, (msg) ->
+  robot.respond /(?:new|add) job [“"](.*?)[“"] (.*)$/i, (msg) ->
     handleNewJob robot, msg, msg.match[1], msg.match[2]
 
-  robot.respond /(?:new|add) job (.*) "(.*?)" *$/i, (msg) ->
+  robot.respond /(?:new|add) job (.*) [“"](.*?)[“"] *$/i, (msg) ->
     handleNewJob robot, msg, msg.match[1], msg.match[2]
 
   robot.respond /(?:new|add) job (.*?) say (.*?) *$/i, (msg) ->


### PR DESCRIPTION
In Slack, when you attempt to create a reminder, it will fail.
This is because this library only does a REGEX match against the ASCII quote character `"` and not the one that get's input when you're typing in slack which is `“`.

This matches both.
