### PR TITLE
Don't want to notify nobody on `list jobs` command when the adapter type is Slack

### DIFF
--- a/src/scripts/cron.coffee
+++ b/src/scripts/cron.coffee
@@ -97,6 +97,7 @@ module.exports = (robot) ->
       room = job.user.reply_to || job.user.room
       if room == msg.message.user.reply_to or room == msg.message.user.room
         text += "#{id}: #{job.pattern} @#{room} \"#{job.message}\"\n"
+    text = robot.adapter.removeFormatting text if robot.adapterName == 'slack'
     msg.send text if text.length > 0
 
   robot.respond /(?:rm|remove|del|delete) job (\d+)/i, (msg) ->


### PR DESCRIPTION
I use Hubot with Slack adapter.

For example, the following job is registerd:

```
0 9 * * * "<!channel> Good morning!"
```

This job notify the channel members in time.

But, I don't want to notify anybody when check the registerd jobs.
